### PR TITLE
Changes to the build system

### DIFF
--- a/CrashLogger/CallTrace.cpp
+++ b/CrashLogger/CallTrace.cpp
@@ -1,5 +1,5 @@
-#include <CrashLogger.hpp>
-#include <ExceptionHandler.hpp>
+#include "CrashLogger.hpp"
+#include "ExceptionHandler.hpp"
 
 namespace CrashLogger::Playtime
 {

--- a/CrashLogger/CrashLogger.hpp
+++ b/CrashLogger/CrashLogger.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include <common/IDebugLog.h>
-#include <Utilities.hpp>
+#include "Utilities.hpp"
 #include <format>
 #include <string>
 #include <chrono>

--- a/CrashLogger/CrashLogger.hpp
+++ b/CrashLogger/CrashLogger.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <common/IDebugLog.h>
+#include <IDebugLog.h>
 #include "Utilities.hpp"
 #include <format>
 #include <string>

--- a/CrashLogger/CrashLogger.sln
+++ b/CrashLogger/CrashLogger.sln
@@ -1,11 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.12.35323.107
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.35826.135
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "common", "..\common\common.vcxproj", "{20C6411C-596F-4B85-BE4E-8BC91F59D8A6}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "common", "..\OBSE\common\common.vcxproj", "{20C6411C-596F-4B85-BE4E-8BC91F59D8A6}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CobbCrashLogger", "CrashLogger.vcxproj", "{A0B4387F-4D59-452A-AF0C-FC5207A55713}"
+	ProjectSection(ProjectDependencies) = postProject
+		{20C6411C-596F-4B85-BE4E-8BC91F59D8A6} = {20C6411C-596F-4B85-BE4E-8BC91F59D8A6}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/CrashLogger/CrashLogger.vcxproj
+++ b/CrashLogger/CrashLogger.vcxproj
@@ -62,7 +62,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(SolutionDir)\..\tes4-crash-logger\obse_plugin_example;$(SolutionDir)\..\tes4-crash-logger;$(SolutionDir);$(SolutionDir)\..;$(SolutionDir)\..\obse\obse;$(SolutionDir)\..\obse\obse_common;$(SolutionDir)\..\common;$(SolutionDir)\..\obse;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\OBSE;$(SolutionDir)..\OBSE\obse\;$(SolutionDir)..\OBSE\obse\obse;$(SolutionDir)..\OBSE\obse\obse_common;$(SolutionDir)..\OBSE\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;OBLIVION_VERSION=0x010201A0;OBLIVION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -72,7 +72,6 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ForcedIncludeFiles>stdafx.h;obse_common/obse_prefix.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
       <PrecompiledHeaderFile>../obse/stdafx.h</PrecompiledHeaderFile>
-      <ObjectFileName>$(IntDir)/%(RelativeDir)/</ObjectFileName>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ExceptionHandling>Async</ExceptionHandling>
     </ClCompile>
@@ -81,7 +80,6 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
-      <AdditionalDependencies>$(SolutionDir)\obse.lib;$(SolutionDir)\common.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Message>
@@ -92,14 +90,14 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)\..\tes4-crash-logger\obse_plugin_example;$(SolutionDir)\..\tes4-crash-logger\;$(SolutionDir)..\CrashLogger;$(SolutionDir);$(SolutionDir)..\;$(SolutionDir)..\OBSE\obse;$(SolutionDir)\..\obse\obse_common;$(SolutionDir)\..\common;$(SolutionDir)..\OBSE;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\OBSE;$(SolutionDir)..\OBSE\obse\;$(SolutionDir)..\OBSE\obse\obse;$(SolutionDir)..\OBSE\obse\obse_common;$(SolutionDir)..\OBSE\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;OBLIVION_VERSION=0x010201A0;OBLIVION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <ForcedIncludeFiles>stdafx.h;obse_common/obse_prefix.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
-      <ObjectFileName>$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <ForcedIncludeFiles>obse\StdAfx.h;obse_common/obse_prefix.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
+      <PrecompiledHeaderFile>obse\StdAfx.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
@@ -117,11 +115,6 @@
       </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
-  <ItemGroup>
-    <Filter Include="OBSE">
-      <UniqueIdentifier>{94aa795e-944e-41af-a0d6-aa5deea207d6}</UniqueIdentifier>
-    </Filter>
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OBSE\common\common.vcxproj">
       <Project>{9292d286-5ee5-4f14-b341-72875cb17d61}</Project>
@@ -145,6 +138,26 @@
     <ClCompile Include="Memory.cpp" />
     <ClCompile Include="Modules.cpp" />
     <ClCompile Include="RegistryStack.cpp" />
+    <ClCompile Include="..\OBSE\obse\obse\GameActorValues.cpp" />
+    <ClCompile Include="..\OBSE\obse\obse\GameAPI.cpp" />
+    <ClCompile Include="..\OBSE\obse\obse\GameBSExtraData.cpp" />
+    <ClCompile Include="..\OBSE\obse\obse\GameData.cpp" />
+    <ClCompile Include="..\OBSE\obse\obse\GameExtraData.cpp" />
+    <ClCompile Include="..\OBSE\obse\obse\GameForms.cpp" />
+    <ClCompile Include="..\OBSE\obse\obse\GameObjects.cpp" />
+    <ClCompile Include="..\OBSE\obse\obse\GameOSDepend.cpp" />
+    <ClCompile Include="..\OBSE\obse\obse\GameTasks.cpp" />
+    <ClCompile Include="..\OBSE\obse\obse\GameTypes.cpp" />
+    <ClCompile Include="..\OBSE\obse\obse\NiAPI.cpp" />
+    <ClCompile Include="..\OBSE\obse\obse\NiNodes.cpp" />
+    <ClCompile Include="..\OBSE\obse\obse\NiObjects.cpp" />
+    <ClCompile Include="..\OBSE\obse\obse\NiRTTI.cpp" />
+    <ClCompile Include="..\OBSE\obse\obse\Script.cpp" />
+    <ClCompile Include="..\OBSE\obse\obse\Utilities.cpp" />
+    <ClCompile Include="..\OBSE\obse\obse_common\SafeWrite.cpp" />
+    <ClCompile Include="..\OBSE\obse\StdAfx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CrashLogger.hpp" />
@@ -154,12 +167,32 @@
     <ClInclude Include="Logging.hpp" />
     <ClInclude Include="RTTI.hpp" />
     <ClInclude Include="Utilities.hpp" />
+    <ClInclude Include="..\OBSE\obse\obse\GameActorValues.h" />
+    <ClInclude Include="..\OBSE\obse\obse\GameAPI.h" />
+    <ClInclude Include="..\OBSE\obse\obse\GameBSExtraData.h" />
+    <ClInclude Include="..\OBSE\obse\obse\GameData.h" />
+    <ClInclude Include="..\OBSE\obse\obse\GameExtraData.h" />
+    <ClInclude Include="..\OBSE\obse\obse\GameForms.h" />
+    <ClInclude Include="..\OBSE\obse\obse\GameObjects.h" />
+    <ClInclude Include="..\OBSE\obse\obse\GameOSDepend.h" />
+    <ClInclude Include="..\OBSE\obse\obse\GameTasks.h" />
+    <ClInclude Include="..\OBSE\obse\obse\GameTypes.h" />
+    <ClInclude Include="..\OBSE\obse\obse\NiAPI.h" />
+    <ClInclude Include="..\OBSE\obse\obse\NiNodes.h" />
+    <ClInclude Include="..\OBSE\obse\obse\NiObjects.h" />
+    <ClInclude Include="..\OBSE\obse\obse\NiRTTI.h" />
+    <ClInclude Include="..\OBSE\obse\obse\ParamInfos.h" />
+    <ClInclude Include="..\OBSE\obse\obse\PluginAPI.h" />
+    <ClInclude Include="..\OBSE\obse\obse\Script.h" />
+    <ClInclude Include="..\OBSE\obse\obse\Utilities.h" />
+    <ClInclude Include="..\OBSE\obse\obse_common\SafeWrite.h" />
+    <ClInclude Include="..\OBSE\obse\StdAfx.h" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\OBSE\obse\obse\GameRTTI_1_1.inl" />
+    <None Include="..\OBSE\obse\obse\GameRTTI_1_2.inl" />
+    <None Include="..\OBSE\obse\obse\GameRTTI_1_2_416.inl" />
     <None Include="exports.def" />
-  </ItemGroup>
-  <ItemGroup>
-    <Library Include="obse.lib" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/CrashLogger/CrashLogger.vcxproj.filters
+++ b/CrashLogger/CrashLogger.vcxproj.filters
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="OBSE">
-      <UniqueIdentifier>{94aa795e-944e-41af-a0d6-aa5deea207d6}</UniqueIdentifier>
+    <Filter Include="obse">
+      <UniqueIdentifier>{a47d661a-32d4-4943-be34-61962d2d4718}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -16,6 +16,61 @@
     <ClCompile Include="LabelsOBSE.cpp" />
     <ClCompile Include="Logging.cpp" />
     <ClCompile Include="Memory.cpp" />
+    <ClCompile Include="..\OBSE\obse\obse\GameActorValues.cpp">
+      <Filter>obse</Filter>
+    </ClCompile>
+    <ClCompile Include="..\OBSE\obse\obse\GameAPI.cpp">
+      <Filter>obse</Filter>
+    </ClCompile>
+    <ClCompile Include="..\OBSE\obse\obse\GameBSExtraData.cpp">
+      <Filter>obse</Filter>
+    </ClCompile>
+    <ClCompile Include="..\OBSE\obse\obse\GameData.cpp">
+      <Filter>obse</Filter>
+    </ClCompile>
+    <ClCompile Include="..\OBSE\obse\obse\GameExtraData.cpp">
+      <Filter>obse</Filter>
+    </ClCompile>
+    <ClCompile Include="..\OBSE\obse\obse\GameForms.cpp">
+      <Filter>obse</Filter>
+    </ClCompile>
+    <ClCompile Include="..\OBSE\obse\obse\GameObjects.cpp">
+      <Filter>obse</Filter>
+    </ClCompile>
+    <ClCompile Include="..\OBSE\obse\obse\GameTasks.cpp">
+      <Filter>obse</Filter>
+    </ClCompile>
+    <ClCompile Include="..\OBSE\obse\obse\GameTypes.cpp">
+      <Filter>obse</Filter>
+    </ClCompile>
+    <ClCompile Include="..\OBSE\obse\obse\NiAPI.cpp">
+      <Filter>obse</Filter>
+    </ClCompile>
+    <ClCompile Include="..\OBSE\obse\obse\NiNodes.cpp">
+      <Filter>obse</Filter>
+    </ClCompile>
+    <ClCompile Include="..\OBSE\obse\obse\NiObjects.cpp">
+      <Filter>obse</Filter>
+    </ClCompile>
+    <ClCompile Include="..\OBSE\obse\obse\NiRTTI.cpp">
+      <Filter>obse</Filter>
+    </ClCompile>
+    <ClCompile Include="..\OBSE\obse\obse\Script.cpp">
+      <Filter>obse</Filter>
+    </ClCompile>
+    <ClCompile Include="..\OBSE\obse\obse\Utilities.cpp">
+      <Filter>obse</Filter>
+    </ClCompile>
+    <ClCompile Include="dllmain.c" />
+    <ClCompile Include="..\OBSE\obse\obse\GameOSDepend.cpp">
+      <Filter>obse</Filter>
+    </ClCompile>
+    <ClCompile Include="..\OBSE\obse\StdAfx.cpp">
+      <Filter>obse</Filter>
+    </ClCompile>
+    <ClCompile Include="..\OBSE\obse\obse_common\SafeWrite.cpp">
+      <Filter>obse</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CrashLogger.hpp" />
@@ -25,11 +80,77 @@
     <ClInclude Include="RTTI.hpp" />
     <ClInclude Include="Formatter.hpp" />
     <ClInclude Include="Logging.hpp" />
+    <ClInclude Include="..\OBSE\obse\obse\GameActorValues.h">
+      <Filter>obse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\OBSE\obse\obse\GameAPI.h">
+      <Filter>obse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\OBSE\obse\obse\GameBSExtraData.h">
+      <Filter>obse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\OBSE\obse\obse\GameData.h">
+      <Filter>obse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\OBSE\obse\obse\GameExtraData.h">
+      <Filter>obse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\OBSE\obse\obse\GameForms.h">
+      <Filter>obse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\OBSE\obse\obse\GameObjects.h">
+      <Filter>obse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\OBSE\obse\obse\GameTasks.h">
+      <Filter>obse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\OBSE\obse\obse\GameTypes.h">
+      <Filter>obse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\OBSE\obse\obse\NiAPI.h">
+      <Filter>obse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\OBSE\obse\obse\NiObjects.h">
+      <Filter>obse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\OBSE\obse\obse\NiNodes.h">
+      <Filter>obse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\OBSE\obse\obse\NiRTTI.h">
+      <Filter>obse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\OBSE\obse\obse\ParamInfos.h">
+      <Filter>obse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\OBSE\obse\obse\PluginAPI.h">
+      <Filter>obse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\OBSE\obse\obse\Script.h">
+      <Filter>obse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\OBSE\obse\obse\Utilities.h">
+      <Filter>obse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\OBSE\obse\obse\GameOSDepend.h">
+      <Filter>obse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\OBSE\obse\StdAfx.h">
+      <Filter>obse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\OBSE\obse\obse_common\SafeWrite.h">
+      <Filter>obse</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="exports.def" />
-  </ItemGroup>
-  <ItemGroup>
-    <Library Include="obse.lib" />
+    <None Include="..\OBSE\obse\obse\GameRTTI_1_1.inl">
+      <Filter>obse</Filter>
+    </None>
+    <None Include="..\OBSE\obse\obse\GameRTTI_1_2.inl">
+      <Filter>obse</Filter>
+    </None>
+    <None Include="..\OBSE\obse\obse\GameRTTI_1_2_416.inl">
+      <Filter>obse</Filter>
+    </None>
   </ItemGroup>
 </Project>

--- a/CrashLogger/CrashLogger.vcxproj.user
+++ b/CrashLogger/CrashLogger.vcxproj.user
@@ -1,8 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <ShowAllFiles>true</ShowAllFiles>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LocalDebuggerCommand>C:\Games\Steam\steamapps\common\Oblivion\Oblivion.exe</LocalDebuggerCommand>
     <LocalDebuggerAttach>false</LocalDebuggerAttach>

--- a/CrashLogger/Definitions.cpp
+++ b/CrashLogger/Definitions.cpp
@@ -1,5 +1,5 @@
-#include <Definitions.hpp>
-#include <CrashLogger.hpp>
+#include "Definitions.hpp"
+#include "CrashLogger.hpp"
 
 #define INIT_MODULE(mod) namespace mod { extern void Init(); }
 

--- a/CrashLogger/Device.cpp
+++ b/CrashLogger/Device.cpp
@@ -1,4 +1,4 @@
-#include <CrashLogger.hpp>
+#include "CrashLogger.hpp"
 
 namespace CrashLogger::Device
 {

--- a/CrashLogger/ExceptionHandler.hpp
+++ b/CrashLogger/ExceptionHandler.hpp
@@ -1,6 +1,6 @@
-#include <CrashLogger.hpp>
+#include "CrashLogger.hpp"
 #include <obse_common/SafeWrite.h>
-#include <Logging.hpp>
+#include "Logging.hpp"
 #include <signal.h>
 
 #define SYMOPT_EX_WINE_NATIVE_MODULES 1000

--- a/CrashLogger/ExceptionHandler.hpp
+++ b/CrashLogger/ExceptionHandler.hpp
@@ -1,5 +1,5 @@
 #include "CrashLogger.hpp"
-#include <obse_common/SafeWrite.h>
+#include "SafeWrite.h"
 #include "Logging.hpp"
 #include <signal.h>
 

--- a/CrashLogger/Formatter.hpp
+++ b/CrashLogger/Formatter.hpp
@@ -1,11 +1,11 @@
 #include <format>
 #include <set>
-#include <GameObjects.h>
-#include <GameData.h>
-#include <GameMagicEffects.h>
-#include <Script.h>
-#include <GameTasks.h>
-#include <NiExtraData.h>
+#include "GameObjects.h"
+#include "GameData.h"
+#include "GameMagicEffects.h"
+#include "Script.h"
+#include "GameTasks.h"
+#include "NiExtraData.h"
 
 // If class is described by a single line, no need to name the variable
 // If there is a member class, if it's one-line, leave it as one-line, if there are several, prepend the name and add offset

--- a/CrashLogger/LabelsOBSE.cpp
+++ b/CrashLogger/LabelsOBSE.cpp
@@ -1,6 +1,6 @@
-#include <CrashLogger.hpp>
-#include <Formatter.hpp>
-#include <RTTI.hpp>
+#include "CrashLogger.hpp"
+#include "Formatter.hpp"
+#include "RTTI.hpp"
 #include <GameForms.h>
 
 namespace CrashLogger::Labels

--- a/CrashLogger/LabelsOBSE.cpp
+++ b/CrashLogger/LabelsOBSE.cpp
@@ -1,7 +1,7 @@
 #include "CrashLogger.hpp"
 #include "Formatter.hpp"
 #include "RTTI.hpp"
-#include <GameForms.h>
+#include "GameForms.h"
 
 namespace CrashLogger::Labels
 {

--- a/CrashLogger/Logging.cpp
+++ b/CrashLogger/Logging.cpp
@@ -1,4 +1,4 @@
-#include <Logging.hpp>
+#include "Logging.hpp"
 
 #include <chrono>
 #include <condition_variable>

--- a/CrashLogger/Memory.cpp
+++ b/CrashLogger/Memory.cpp
@@ -1,7 +1,7 @@
 #include "CrashLogger.hpp"
 #include <psapi.h>
-#include <GameAPI.h>
-#include <PluginManager.h>
+#include "GameAPI.h"
+#include "PluginManager.h"
 
 #define PRINT_HEAPS 1
 #define PRINT_POOLS 0

--- a/CrashLogger/Memory.cpp
+++ b/CrashLogger/Memory.cpp
@@ -1,4 +1,4 @@
-#include <CrashLogger.hpp>
+#include "CrashLogger.hpp"
 #include <psapi.h>
 #include <GameAPI.h>
 #include <PluginManager.h>
@@ -16,7 +16,7 @@ namespace CrashLogger::Memory
 		const auto hProcess = GetCurrentProcess();
 
 
-		PROCESS_MEMORY_COUNTERS_EX2 pmc = {};
+		PROCESS_MEMORY_COUNTERS_EX pmc = {};
 		pmc.cb = sizeof(pmc);
 
 		// Get physical memory size

--- a/CrashLogger/Modules.cpp
+++ b/CrashLogger/Modules.cpp
@@ -1,5 +1,5 @@
-#include <CrashLogger.hpp>
-#include <Utilities.h>
+#include "CrashLogger.hpp"
+#include "Utilities.h"
 
 #pragma comment (lib, "version.lib")
 

--- a/CrashLogger/RegistryStack.cpp
+++ b/CrashLogger/RegistryStack.cpp
@@ -1,4 +1,4 @@
-#include <CrashLogger.hpp>
+#include "CrashLogger.hpp"
 #include <ranges>
 #include <iostream>
 #include <ios>

--- a/CrashLogger/Utilities.hpp
+++ b/CrashLogger/Utilities.hpp
@@ -1,3 +1,4 @@
+#include <format>
 
 inline int ExceptionFilter(unsigned int code)
 {

--- a/CrashLogger/main.cpp
+++ b/CrashLogger/main.cpp
@@ -1,8 +1,8 @@
 #include "obse/PluginAPI.h"
 
-#include <Definitions.hpp>
+#include "Definitions.hpp"
 #include "CrashLogger.hpp"
-#include <Logging.hpp>
+#include "Logging.hpp"
 #include <iostream>
 
 IDebugLog    gLog("CrashLogger.log");

--- a/CrashLogger/main.cpp
+++ b/CrashLogger/main.cpp
@@ -1,4 +1,4 @@
-#include "obse/PluginAPI.h"
+#include "PluginAPI.h"
 
 #include "Definitions.hpp"
 #include "CrashLogger.hpp"


### PR DESCRIPTION
Some changes to the build system to allow a less heavy DLL in both Release and Debug mode, it also have some works to clearly separate project related includes (#include "file.h") and external includes (#include <ffile.h>). Prevent a path traversal causing the OBSE object being created outside Release and Debug folders, causing problems when trying to create both.

Also updated the xOBSE submodule