### PR TITLE
Add Vectored Exception Handler, fix a possible crash on stack / register reading

### DIFF
--- a/CrashLogger/CrashLogger.hpp
+++ b/CrashLogger/CrashLogger.hpp
@@ -37,6 +37,13 @@ namespace CrashLogger::PDB
 
 namespace CrashLogger
 {
+	class SE_Exception
+	{
+	public:
+		SE_Exception() {}
+		~SE_Exception() {}
+	};
+
 	template<typename T>
 	class Dereference {
 		intptr_t pointer;
@@ -57,6 +64,7 @@ namespace CrashLogger
 			if (IsValidPointer()) {
 				return reinterpret_cast<T*>(pointer);
 			}
+			return nullptr;
 
 			//throw std::runtime_error("Bad dereference");
 		}
@@ -65,7 +73,7 @@ namespace CrashLogger
 			if (IsValidPointer()) {
 				return reinterpret_cast<T*>(pointer);
 			}
-
+			return nullptr;
 			//throw std::runtime_error("Bad dereference");
 		}
 

--- a/CrashLogger/CrashLogger.vcxproj
+++ b/CrashLogger/CrashLogger.vcxproj
@@ -107,6 +107,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <TargetMachine>MachineX86</TargetMachine>
+     <ExceptionHandling>Async</ExceptionHandling>
     </Link>
     <PostBuildEvent>
       <Message>

--- a/CrashLogger/ExceptionHandler.hpp
+++ b/CrashLogger/ExceptionHandler.hpp
@@ -138,6 +138,10 @@ namespace CrashLogger::PDB
 
 namespace CrashLogger
 {
+	void trans_func( unsigned int u, EXCEPTION_POINTERS* pExp )
+	{
+		throw SE_Exception();
+	}
 
 	void LogPlaytime(EXCEPTION_POINTERS* info) {
 		__try {
@@ -180,7 +184,7 @@ namespace CrashLogger
 			Registry::Process(info);
 		}
 		__except (EXCEPTION_EXECUTE_HANDLER) {
-			_MESSAGE("Failed to log registry.");
+			_MESSAGE("Failed to log registers.");
 		}
 	}
 
@@ -222,9 +226,8 @@ namespace CrashLogger
 
 	void Log(EXCEPTION_POINTERS* info)
 	{
-		
 		const auto begin = std::chrono::system_clock::now();
-		//
+
 		_MESSAGE("Processing playtime");
 		LogPlaytime(info);
 		_MESSAGE("Processing exception");
@@ -237,7 +240,7 @@ namespace CrashLogger
 		//LogDevice(info);
 		_MESSAGE("Processing calltrace");
 		LogCalltrace(info);
-		_MESSAGE("Processing registry");
+		_MESSAGE("Processing registers");
 		LogRegistry(info);
 		_MESSAGE("Processing stack");
 		LogStack(info);

--- a/CrashLogger/Formatter.hpp
+++ b/CrashLogger/Formatter.hpp
@@ -42,6 +42,7 @@ inline auto LogClass(TESForm& obj)
 	UInt32 modIndex = refID >> 24;
 	std::string modName;
 	std::string refName = obj.GetEditorName();
+	std::string  loaded = obj.flags &  TESForm::FormFlags::kFormFlags_Linked ? "" : "<Not Linked>";
 	if (modIndex == 0xFF) {
 		if (refName.empty())
 		{
@@ -52,7 +53,7 @@ inline auto LogClass(TESForm& obj)
 				refName = std::format("Temp {} ({})", TypeNames[obj.typeID], obj.GetName());
 			}
 		}
-		vec.push_back(std::format("ID: {:08X} ({})", refID, refName));
+		vec.push_back(std::format("ID: {:08X} ({}) {}", refID, refName, loaded));
 	}
 	else if (modIndex != 0xFF) {
 		std::string modName = (*g_dataHandler)->GetNthModName(modIndex);
@@ -67,7 +68,7 @@ inline auto LogClass(TESForm& obj)
 		else {
 			modName = std::format("\"{}\"", modName);
 		}
-		vec.push_back(std::format("ID: {:08X} ({}) : (Plugin: {})", refID, refName, modName));
+		vec.push_back(std::format("ID: {:08X} ({}) : (Plugin: {}) {}", refID, refName, modName, loaded));
 	}
 	return vec;
 }
@@ -105,7 +106,7 @@ inline std::vector<std::string>  LogClass(const BaseProcess& obj)
 			&& reinterpret_cast<Actor*>(iter)->pkBaseProcess == &obj)
 			return LogClass(reinterpret_cast<const TESObjectREFR&>(*iter));
 	return {};
-} 
+}
 
 inline auto LogClass(const NiControllerSequence& obj)
 {
@@ -135,7 +136,7 @@ inline std::vector<std::string> LogClass(const AnimSequenceMultiple& obj)
 		vec.append_range(LogMember(std::format("AnimSequence{}", i), *iter));
 	}
 	return vec;
-} 
+}
 
 inline std::vector<std::string> LogClass(const NiExtraData& obj)
 {
@@ -266,7 +267,7 @@ inline std::vector<std::string> LogClass(const hkpWorldObject& obj)
 		vec.append_range(LogMember("Collision Object:", reinterpret_cast<const NiCollisionObject&>(*object)));
 
 	return vec;
-} 
+}
 
 inline std::vector<std::string> LogClass(const IMemoryHeap& obj)
 {

--- a/CrashLogger/main.cpp
+++ b/CrashLogger/main.cpp
@@ -78,9 +78,10 @@ extern "C" {
    bool OBSEPlugin_Load(const OBSEInterface* obse) {
       g_pluginHandle = obse->GetPluginHandle();
       
-      if (!obse->isEditor)
+      if (!obse->isEditor){
           InitLog(GetCurPath());
           Inits();
+      }
           //CobbPatches::CrashLog::Apply(false);
       return true;
    }


### PR DESCRIPTION
Added Vectored exception Handling that allow the logger to get info on some more exceptions, like debug breaks or stack overflows. 
Note that walking a stack overflow with the current code  is still problematic, format and other C++ functions are too heavy on stack usage ,  and doing it properly require setting up a separate thread. Possibly in a follow up PR

Also fixed an issue where decoding the stack could crash when trying to decode as a string some pointers. 